### PR TITLE
Disable mongodb driver logging

### DIFF
--- a/src/main/java/cc/kasumi/commons/mongodb/MDatabase.java
+++ b/src/main/java/cc/kasumi/commons/mongodb/MDatabase.java
@@ -8,6 +8,8 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import lombok.Getter;
 import org.bukkit.Bukkit;
+import java.util.logging.Logger;
+import java.util.logging.Level;
 
 
 @Getter
@@ -16,6 +18,13 @@ public class MDatabase {
     private MongoDatabase database;
 
     public MDatabase(String uri, String databaseName) {
+        // Disable MongoDB driver logging
+        Logger.getLogger("org.mongodb.driver").setLevel(Level.WARNING);
+        Logger.getLogger("org.mongodb.driver.cluster").setLevel(Level.WARNING);
+        Logger.getLogger("org.mongodb.driver.connection").setLevel(Level.WARNING);
+        Logger.getLogger("org.mongodb.driver.management").setLevel(Level.WARNING);
+        Logger.getLogger("org.mongodb.driver.protocol").setLevel(Level.WARNING);
+        
         ConnectionString connString = new ConnectionString(uri);
 
         MongoClientSettings settings = MongoClientSettings.builder()

--- a/src/main/java/cc/kasumi/commons/mongodb/MDatabase.java
+++ b/src/main/java/cc/kasumi/commons/mongodb/MDatabase.java
@@ -8,8 +8,6 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoDatabase;
 import lombok.Getter;
 import org.bukkit.Bukkit;
-import java.util.logging.Logger;
-import java.util.logging.Level;
 
 
 @Getter
@@ -18,13 +16,6 @@ public class MDatabase {
     private MongoDatabase database;
 
     public MDatabase(String uri, String databaseName) {
-        // Disable MongoDB driver logging
-        Logger.getLogger("org.mongodb.driver").setLevel(Level.WARNING);
-        Logger.getLogger("org.mongodb.driver.cluster").setLevel(Level.WARNING);
-        Logger.getLogger("org.mongodb.driver.connection").setLevel(Level.WARNING);
-        Logger.getLogger("org.mongodb.driver.management").setLevel(Level.WARNING);
-        Logger.getLogger("org.mongodb.driver.protocol").setLevel(Level.WARNING);
-        
         ConnectionString connString = new ConnectionString(uri);
 
         MongoClientSettings settings = MongoClientSettings.builder()

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,0 +1,17 @@
+# Logging configuration to disable MongoDB driver verbose logging
+# Set root logger level
+.level = INFO
+
+# Disable MongoDB driver logging
+org.mongodb.driver.level = WARNING
+org.mongodb.driver.cluster.level = WARNING
+org.mongodb.driver.connection.level = WARNING
+org.mongodb.driver.management.level = WARNING
+org.mongodb.driver.protocol.level = WARNING
+
+# Alternative: Completely disable MongoDB logging (uncomment if needed)
+# org.mongodb.driver.level = OFF
+# org.mongodb.driver.cluster.level = OFF
+# org.mongodb.driver.connection.level = OFF
+# org.mongodb.driver.management.level = OFF
+# org.mongodb.driver.protocol.level = OFF


### PR DESCRIPTION
Add `logging.properties` to suppress verbose MongoDB driver connection logging.

---
<a href="https://cursor.com/background-agent?bcId=bc-826b1744-ca36-4814-9e2e-bc8d2a62720f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-826b1744-ca36-4814-9e2e-bc8d2a62720f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>